### PR TITLE
Use latest php-cs-fixer 2.17.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "psr/simple-cache-implementation": "~1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.16.7",
+        "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },

--- a/lib/InvalidArgumentException.php
+++ b/lib/InvalidArgumentException.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Sabre\Cache;
 
 /**
- * This exception is thrown if an invalid arugment is passed to one of the
- * caching functions, such as a non-string cache key.
+ * This exception is thrown if an invalid argument is passed to one of the
+ * caching functions, such as a non-string cache key. It extends the PHP built-in
+ * InvalidArgumentException with PSR-16 "Simple Cache".
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (https://evertpot.com/)
  * @license http://sabre.io/license/
  */
-class InvalidArgumentException extends \InvalidArgumentException // PHP built-in
-    implements \Psr\SimpleCache\InvalidArgumentException // PSR-16
+class InvalidArgumentException extends \InvalidArgumentException implements \Psr\SimpleCache\InvalidArgumentException
 {
 }


### PR DESCRIPTION
The latest php-cs-fixer finds some new things. Code changes were needed in https://github.com/sabre-io/dav/pull/1316 for `sabre/dav`. We might as well consistently make sure to use at least this version 2.17.1 in all repos so that we are doing consistent code-style checking.

It complains about comments at the end of lines in the class definition. I removed those and wrote some words in the main comment block.