### PR TITLE
Correct some minor typos and get unit tests running correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,20 @@ jobs:
           - php-versions: '7.1'
             coverage: 'none'
             code-analysis: 'yes'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Memcached
+        uses: KeisukeYamashita/memcached-actions@v1
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: memcached
+          extensions: memcached, apcu
+          ini-values: apc.enable_cli=1"
           coverage: ${{ matrix.coverage }}
           tools: composer
 
@@ -57,6 +62,8 @@ jobs:
 
       - name: Test with phpunit
         run: vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover clover.xml
+        env:
+          MEMCACHED_SERVER: 127.0.0.1
 
       - name: Code Coverage
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Read [PSR-16][5] for the API. We follow it to the letter.
 
 ### In-memory cache
 
-This is useful as a test-double or long running processes. The `Memory` cache
+This is useful as a test-double for long-running processes. The `Memory` cache
 only lasts as long as the object does.
 
 ```php

--- a/lib/Memcached.php
+++ b/lib/Memcached.php
@@ -242,5 +242,7 @@ class Memcached implements CacheInterface
             throw new InvalidArgumentException('$keys must be iterable');
         }
         $this->memcached->deleteMulti($keys);
+
+        return true;
     }
 }

--- a/lib/Memcached.php
+++ b/lib/Memcached.php
@@ -12,7 +12,7 @@ use Traversable;
 /**
  * The Memcached cache uses Memcache to store values.
  *
- * This is a simple PSR-16 wrappe around memcached. To get it going, pass a
+ * This is a simple PSR-16 wrapper around memcached. To get it going, pass a
  * fully instantiated Memcached object to its constructor.
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)


### PR DESCRIPTION
This PR is really an excuse to make the new GitHub workflows run, and get them passing.

1) correct some minor typos
2) add a return to the end of `deleteMultiple` which was missing (report by code analysis)
3) Setup memcached server and apcu for tests

This makes all 72 unit tests run and pass, like they did with Travis.