### PR TITLE
fix ctype_digit() warnings

### DIFF
--- a/lib/Memcached.php
+++ b/lib/Memcached.php
@@ -80,12 +80,14 @@ class Memcached implements CacheInterface
         if (!is_string($key)) {
             throw new InvalidArgumentException('$key must be a string');
         }
-        if ($ttl instanceof DateInterval) {
-            $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
-        } elseif (is_int($ttl) || ctype_digit($ttl)) {
-            $expire = time() + $ttl;
-        } else {
-            $expire = 0;
+
+        $expire = 0;
+        if (isset($ttl)) {
+            if ($ttl instanceof DateInterval) {
+                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+                $expire = time() + $ttl;
+            }
         }
 
         return $this->memcached->set($key, $value, $expire);
@@ -208,12 +210,14 @@ class Memcached implements CacheInterface
         } elseif (!is_array($values)) {
             throw new InvalidArgumentException('$values must be iterable');
         }
-        if ($ttl instanceof DateInterval) {
-            $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
-        } elseif (is_int($ttl) || ctype_digit($ttl)) {
-            $expire = time() + $ttl;
-        } else {
-            $expire = 0;
+
+        $expire = 0;
+        if (isset($ttl)) {
+            if ($ttl instanceof DateInterval) {
+                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+                $expire = time() + $ttl;
+            }
         }
 
         return $this->memcached->setMulti(

--- a/lib/Memory.php
+++ b/lib/Memory.php
@@ -79,12 +79,14 @@ class Memory implements CacheInterface
         if (!is_string($key)) {
             throw new InvalidArgumentException('$key must be a string');
         }
-        if ($ttl instanceof DateInterval) {
-            $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
-        } elseif (is_int($ttl) || ctype_digit($ttl)) {
-            $expire = time() + $ttl;
-        } else {
-            $expire = null;
+
+        $expire = null;
+        if (isset($ttl)) {
+            if ($ttl instanceof DateInterval) {
+                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+                $expire = time() + $ttl;
+            }
         }
         $this->cache[$key] = [$expire, $value];
 


### PR DESCRIPTION
This PR fixes #37 and upcoming changes on ctype_digit() (see: https://wiki.php.net/rfc/deprecations_php_8_1#ctype_function_family_accepts_int_parameters)