### PR TITLE
Adjust code style to meet current php-cs-fixer

### DIFF
--- a/lib/Apcu.php
+++ b/lib/Apcu.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Cache;
 
-use DateInterval;
-use DateTime;
 use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
@@ -49,14 +47,14 @@ class Apcu implements CacheInterface
      * Persists data in the cache, uniquely referenced by a key with an
      * optional expiration TTL time.
      *
-     * @param string                $key   the key of the item to store
-     * @param mixed                 $value the value of the item to store, must
-     *                                     be serializable
-     * @param int|DateInterval|null $ttl   Optional. The TTL value of this item.
-     *                                     If no value is sent and the driver
-     *                                     supports TTL then the library may set
-     *                                     a default value for it or let the
-     *                                     driver take care of that.
+     * @param string                 $key   the key of the item to store
+     * @param mixed                  $value the value of the item to store, must
+     *                                      be serializable
+     * @param int|\DateInterval|null $ttl   Optional. The TTL value of this item.
+     *                                      If no value is sent and the driver
+     *                                      supports TTL then the library may set
+     *                                      a default value for it or let the
+     *                                      driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -68,9 +66,9 @@ class Apcu implements CacheInterface
         if (!is_string($key)) {
             throw new InvalidArgumentException('$key must be a string');
         }
-        if ($ttl instanceof DateInterval) {
+        if ($ttl instanceof \DateInterval) {
             // Converting to a TTL in seconds
-            $ttl = (new DateTime('now'))->add($ttl)->getTimeStamp() - time();
+            $ttl = (new \DateTime('now'))->add($ttl)->getTimeStamp() - time();
         }
 
         return apcu_store($key, $value, (int) $ttl);
@@ -131,13 +129,13 @@ class Apcu implements CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable              $values a list of key => value pairs for a
-     *                                      multiple-set operation
-     * @param int|DateInterval|null $ttl    Optional. The TTL value of this
-     *                                      item. If no value is sent and the
-     *                                      driver supports TTL then the library
-     *                                      may set a default value for it or
-     *                                      let the driver take care of that.
+     * @param iterable               $values a list of key => value pairs for a
+     *                                       multiple-set operation
+     * @param int|\DateInterval|null $ttl    Optional. The TTL value of this
+     *                                       item. If no value is sent and the
+     *                                       driver supports TTL then the library
+     *                                       may set a default value for it or
+     *                                       let the driver take care of that.
      *
      * @return bool|array true on success and false on failure (or array of true-false)
      *
@@ -147,16 +145,16 @@ class Apcu implements CacheInterface
      */
     public function setMultiple($values, $ttl = null)
     {
-        if (!is_array($values) && !$values instanceof Traversable) {
+        if (!is_array($values) && !$values instanceof \Traversable) {
             throw new InvalidArgumentException('$values must be traversable');
         }
 
-        if ($ttl instanceof DateInterval) {
+        if ($ttl instanceof \DateInterval) {
             // Converting to a TTL in seconds
-            $ttl = (new DateTime('now'))->add($ttl)->getTimeStamp() - time();
+            $ttl = (new \DateTime('now'))->add($ttl)->getTimeStamp() - time();
         }
 
-        if ($values instanceof Traversable) {
+        if ($values instanceof \Traversable) {
             $values = iterator_to_array($values);
         }
 
@@ -177,7 +175,7 @@ class Apcu implements CacheInterface
      */
     public function deleteMultiple($keys)
     {
-        if ($keys instanceof Traversable) {
+        if ($keys instanceof \Traversable) {
             $keys = iterator_to_array($keys);
         } elseif (!is_array($keys)) {
             throw new InvalidArgumentException('$keys must be iterable');

--- a/lib/Memcached.php
+++ b/lib/Memcached.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Cache;
 
-use DateInterval;
-use DateTime;
 use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
@@ -60,14 +58,14 @@ class Memcached implements CacheInterface
      * Persists data in the cache, uniquely referenced by a key with an
      * optional expiration TTL time.
      *
-     * @param string                $key   the key of the item to store
-     * @param mixed                 $value the value of the item to store, must
-     *                                     be serializable
-     * @param int|DateInterval|null $ttl   Optional. The TTL value of this item.
-     *                                     If no value is sent and the driver
-     *                                     supports TTL then the library may set
-     *                                     a default value for it or let the
-     *                                     driver take care of that.
+     * @param string                 $key   the key of the item to store
+     * @param mixed                  $value the value of the item to store, must
+     *                                      be serializable
+     * @param int|\DateInterval|null $ttl   Optional. The TTL value of this item.
+     *                                      If no value is sent and the driver
+     *                                      supports TTL then the library may set
+     *                                      a default value for it or let the
+     *                                      driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -82,8 +80,8 @@ class Memcached implements CacheInterface
 
         $expire = 0;
         if (isset($ttl)) {
-            if ($ttl instanceof DateInterval) {
-                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            if ($ttl instanceof \DateInterval) {
+                $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
             } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
                 $expire = time() + $ttl;
             }
@@ -167,7 +165,7 @@ class Memcached implements CacheInterface
      */
     public function getMultiple($keys, $default = null): iterable
     {
-        if ($keys instanceof Traversable) {
+        if ($keys instanceof \Traversable) {
             $keys = iterator_to_array($keys);
         } elseif (!is_array($keys)) {
             throw new InvalidArgumentException('$keys must be iterable');
@@ -186,13 +184,13 @@ class Memcached implements CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable              $values a list of key => value pairs for a
-     *                                      multiple-set operation
-     * @param int|DateInterval|null $ttl    Optional. The TTL value of this
-     *                                      item. If no value is sent and the
-     *                                      driver supports TTL then the library
-     *                                      may set a default value for it or
-     *                                      let the driver take care of that.
+     * @param iterable               $values a list of key => value pairs for a
+     *                                       multiple-set operation
+     * @param int|\DateInterval|null $ttl    Optional. The TTL value of this
+     *                                       item. If no value is sent and the
+     *                                       driver supports TTL then the library
+     *                                       may set a default value for it or
+     *                                       let the driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -202,7 +200,7 @@ class Memcached implements CacheInterface
      */
     public function setMultiple($values, $ttl = null): bool
     {
-        if ($values instanceof Traversable) {
+        if ($values instanceof \Traversable) {
             $values = iterator_to_array($values);
         } elseif (!is_array($values)) {
             throw new InvalidArgumentException('$values must be iterable');
@@ -210,8 +208,8 @@ class Memcached implements CacheInterface
 
         $expire = 0;
         if (isset($ttl)) {
-            if ($ttl instanceof DateInterval) {
-                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            if ($ttl instanceof \DateInterval) {
+                $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
             } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
                 $expire = time() + $ttl;
             }
@@ -237,7 +235,7 @@ class Memcached implements CacheInterface
      */
     public function deleteMultiple($keys): bool
     {
-        if ($keys instanceof Traversable) {
+        if ($keys instanceof \Traversable) {
             $keys = iterator_to_array($keys);
         } elseif (!is_array($keys)) {
             throw new InvalidArgumentException('$keys must be iterable');

--- a/lib/Memory.php
+++ b/lib/Memory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Cache;
 
-use DateInterval;
-use DateTime;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -67,14 +65,14 @@ class Memory implements CacheInterface
      * Persists data in the cache, uniquely referenced by a key with an
      * optional expiration TTL time.
      *
-     * @param string                $key   the key of the item to store
-     * @param mixed                 $value the value of the item to store, must
-     *                                     be serializable
-     * @param int|DateInterval|null $ttl   Optional. The TTL value of this item.
-     *                                     If no value is sent and the driver
-     *                                     supports TTL then the library may set
-     *                                     a default value for it or let the
-     *                                     driver take care of that.
+     * @param string                 $key   the key of the item to store
+     * @param mixed                  $value the value of the item to store, must
+     *                                      be serializable
+     * @param int|\DateInterval|null $ttl   Optional. The TTL value of this item.
+     *                                      If no value is sent and the driver
+     *                                      supports TTL then the library may set
+     *                                      a default value for it or let the
+     *                                      driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -89,8 +87,8 @@ class Memory implements CacheInterface
 
         $expire = null;
         if (isset($ttl)) {
-            if ($ttl instanceof DateInterval) {
-                $expire = (new DateTime('now'))->add($ttl)->getTimeStamp();
+            if ($ttl instanceof \DateInterval) {
+                $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
             } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
                 $expire = time() + $ttl;
             }

--- a/lib/MultipleTrait.php
+++ b/lib/MultipleTrait.php
@@ -37,7 +37,7 @@ trait MultipleTrait
      */
     public function getMultiple($keys, $default = null)
     {
-        if (!is_array($keys) && !$keys instanceof Traversable) {
+        if (!is_array($keys) && !$keys instanceof \Traversable) {
             throw new InvalidArgumentException('$keys must be traversable');
         }
 
@@ -65,7 +65,7 @@ trait MultipleTrait
      */
     public function setMultiple($values, $ttl = null): bool
     {
-        if (!is_array($values) && !$values instanceof Traversable) {
+        if (!is_array($values) && !$values instanceof \Traversable) {
             throw new InvalidArgumentException('$values must be traversable');
         }
 
@@ -93,7 +93,7 @@ trait MultipleTrait
      */
     public function deleteMultiple($keys): bool
     {
-        if (!is_array($keys) && !$keys instanceof Traversable) {
+        if (!is_array($keys) && !$keys instanceof \Traversable) {
             throw new InvalidArgumentException('$keys must be traversable');
         }
 

--- a/tests/Cache/AbstractCacheTest.php
+++ b/tests/Cache/AbstractCacheTest.php
@@ -64,6 +64,7 @@ abstract class AbstractCacheTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @depends testSetGet
+     *
      * @slow
      */
     public function testSetExpire(): void
@@ -79,6 +80,7 @@ abstract class AbstractCacheTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @depends testSetGet
+     *
      * @slow
      */
     public function testSetExpireDateInterval(): void
@@ -244,6 +246,7 @@ abstract class AbstractCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * @depends testSetGetMultiple
      * @depends testSetExpire
+     *
      * @slow
      */
     public function testSetMultipleExpireDateIntervalNotExpired(): void

--- a/tests/Cache/ApcuTest.php
+++ b/tests/Cache/ApcuTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Cache;
 
 use Psr\SimpleCache\CacheInterface;
-use Traversable;
 
 class ApcuTest extends AbstractCacheTest
 {
@@ -89,7 +88,7 @@ class ApcuTest extends AbstractCacheTest
         // sleep(2);
 
         $result = $cache->getMultiple(array_keys($values), 'not-found');
-        $this->assertTrue($result instanceof Traversable || is_array($result));
+        $this->assertTrue($result instanceof \Traversable || is_array($result));
         // $count = 0;
 
         // $expected = [
@@ -134,7 +133,7 @@ class ApcuTest extends AbstractCacheTest
         // sleep(2);
 
         $result = $cache->getMultiple(array_keys($values), 'not-found');
-        $this->assertTrue($result instanceof Traversable || is_array($result));
+        $this->assertTrue($result instanceof \Traversable || is_array($result));
         // $count = 0;
 
         // $expected = [


### PR DESCRIPTION
php-cs-fixer is reporting these. I guess there has been a newer php-cs-fixer version released that is different.

It wants "root" classes and functions to use the leading `\` - `\DateTime`.

We could change some php-cs-fixer rule settings, but actually it is easy to accept these code-style changes.