### PR TITLE
Add phpstan-phpunit to test tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14.0",
         "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/extension-installer": "^1.2",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
@@ -62,5 +64,10 @@
             "composer cs-fixer",
             "composer phpunit"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
Related comment https://github.com/sabre-io/event/pull/104#issuecomment-1422497179

https://github.com/phpstan/phpstan-phpunit

If I add a bit of code like this to a test:
```
            self::assertSame(true, $value);
```

then:
```
composer phpstan
> phpstan analyse lib tests
 ! [NOTE] The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process
 !        will not halt at breakpoints.                                                                                 
Note: Using configuration file /home/phil/git/sabre-io/cache/phpstan.neon.
 10/10 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
 ------ --------------------------------------------------------------------------- 
  Line   tests/Cache/AbstractCacheTest.php                                          
 ------ --------------------------------------------------------------------------- 
  441    You should use assertTrue() instead of assertSame() when expecting "true"  
 ------ --------------------------------------------------------------------------- 
                                                                                                                        
 [ERROR] Found 1 error                                                                                                  
                                                                                                                        
Script phpstan analyse lib tests handling the phpstan event returned with error code 1
```

So it is doing extra analysis of unit test code.

That happens even though phpstan level is just 1 in this repo. If the phpstan level is 4 or higher, then the docs say that there are more things checked.