### PR TITLE
Implement phpstan-strict-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "friendsofphp/php-cs-fixer": "^3.14.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-strict-rules": "^1.4",
         "phpstan/extension-installer": "^1.2",
         "phpunit/phpunit" : "^9.6"
     },

--- a/lib/Memcached.php
+++ b/lib/Memcached.php
@@ -58,14 +58,14 @@ class Memcached implements CacheInterface
      * Persists data in the cache, uniquely referenced by a key with an
      * optional expiration TTL time.
      *
-     * @param string                 $key   the key of the item to store
-     * @param mixed                  $value the value of the item to store, must
-     *                                      be serializable
-     * @param int|\DateInterval|null $ttl   Optional. The TTL value of this item.
-     *                                      If no value is sent and the driver
-     *                                      supports TTL then the library may set
-     *                                      a default value for it or let the
-     *                                      driver take care of that.
+     * @param string                        $key   the key of the item to store
+     * @param mixed                         $value the value of the item to store, must
+     *                                             be serializable
+     * @param int|string|\DateInterval|null $ttl   Optional. The TTL value of this item.
+     *                                             If no value is sent and the driver
+     *                                             supports TTL then the library may set
+     *                                             a default value for it or let the
+     *                                             driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -82,7 +82,7 @@ class Memcached implements CacheInterface
         if (isset($ttl)) {
             if ($ttl instanceof \DateInterval) {
                 $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
-            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+            } elseif (is_int($ttl) || (is_string($ttl) && ctype_digit($ttl))) {
                 $expire = time() + $ttl;
             }
         }
@@ -184,13 +184,13 @@ class Memcached implements CacheInterface
     /**
      * Persists a set of key => value pairs in the cache, with an optional TTL.
      *
-     * @param iterable               $values a list of key => value pairs for a
-     *                                       multiple-set operation
-     * @param int|\DateInterval|null $ttl    Optional. The TTL value of this
-     *                                       item. If no value is sent and the
-     *                                       driver supports TTL then the library
-     *                                       may set a default value for it or
-     *                                       let the driver take care of that.
+     * @param iterable                      $values a list of key => value pairs for a
+     *                                              multiple-set operation
+     * @param int|string|\DateInterval|null $ttl    Optional. The TTL value of this
+     *                                              item. If no value is sent and the
+     *                                              driver supports TTL then the library
+     *                                              may set a default value for it or
+     *                                              let the driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -210,7 +210,7 @@ class Memcached implements CacheInterface
         if (isset($ttl)) {
             if ($ttl instanceof \DateInterval) {
                 $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
-            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+            } elseif (is_int($ttl) || (is_string($ttl) && ctype_digit($ttl))) {
                 $expire = time() + $ttl;
             }
         }

--- a/lib/Memory.php
+++ b/lib/Memory.php
@@ -65,14 +65,14 @@ class Memory implements CacheInterface
      * Persists data in the cache, uniquely referenced by a key with an
      * optional expiration TTL time.
      *
-     * @param string                 $key   the key of the item to store
-     * @param mixed                  $value the value of the item to store, must
-     *                                      be serializable
-     * @param int|\DateInterval|null $ttl   Optional. The TTL value of this item.
-     *                                      If no value is sent and the driver
-     *                                      supports TTL then the library may set
-     *                                      a default value for it or let the
-     *                                      driver take care of that.
+     * @param string                        $key   the key of the item to store
+     * @param mixed                         $value the value of the item to store, must
+     *                                             be serializable
+     * @param int|string|\DateInterval|null $ttl   Optional. The TTL value of this item.
+     *                                             If no value is sent and the driver
+     *                                             supports TTL then the library may set
+     *                                             a default value for it or let the
+     *                                             driver take care of that.
      *
      * @return bool true on success and false on failure
      *
@@ -89,7 +89,7 @@ class Memory implements CacheInterface
         if (isset($ttl)) {
             if ($ttl instanceof \DateInterval) {
                 $expire = (new \DateTime('now'))->add($ttl)->getTimeStamp();
-            } elseif (is_int($ttl) || ctype_digit((string) $ttl)) {
+            } elseif (is_int($ttl) || (is_string($ttl) && ctype_digit($ttl))) {
                 $expire = time() + $ttl;
             }
         }

--- a/tests/Cache/ApcuTest.php
+++ b/tests/Cache/ApcuTest.php
@@ -11,14 +11,14 @@ class ApcuTest extends AbstractCacheTest
     public function getCache(): CacheInterface
     {
         if (!function_exists('apcu_store')) {
-            $this->markTestSkipped('Apcu extension is not loaded');
+            self::markTestSkipped('Apcu extension is not loaded');
         }
         if (!ini_get('apc.enabled')) {
-            $this->markTestSkipped('apc.enabled is set to 0. Enable it via php.ini');
+            self::markTestSkipped('apc.enabled is set to 0. Enable it via php.ini');
         }
 
         if ('cli' === php_sapi_name() && !ini_get('apc.enable_cli')) {
-            $this->markTestSkipped('apc.enable_cli is set to 0. Enable it via php.ini');
+            self::markTestSkipped('apc.enable_cli is set to 0. Enable it via php.ini');
         }
 
         return new Apcu();

--- a/tests/Cache/MemcachedTest.php
+++ b/tests/Cache/MemcachedTest.php
@@ -11,11 +11,11 @@ class MemcachedTest extends AbstractCacheTest
     public function getCache(): CacheInterface
     {
         if (!class_exists('Memcached')) {
-            $this->markTestSkipped('Memcached extension is not loaded');
+            self::markTestSkipped('Memcached extension is not loaded');
         }
 
         if (!isset($_SERVER['MEMCACHED_SERVER'])) {
-            $this->markTestSkipped('MEMCACHED_SERVER environment variable is not set');
+            self::markTestSkipped('MEMCACHED_SERVER environment variable is not set');
         }
 
         $memcached = new \Memcached();


### PR DESCRIPTION
Doing this makes the "Dynamic call to static method" check happen. It found a few more of those.
```
------ ---------------------------------------------------------------------------- 
  Line   tests/Cache/ApcuTest.php                                                    
 ------ ---------------------------------------------------------------------------- 
  14     Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().  
  17     Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().  
  21     Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().  
 ------ ---------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------- 
  Line   tests/Cache/MemcachedTest.php                                               
 ------ ---------------------------------------------------------------------------- 
  14     Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().  
  18     Dynamic call to static method PHPUnit\Framework\Assert::markTestSkipped().  
 ------ ---------------------------------------------------------------------------- 
```
