### PR TITLE
Prepare 2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+2.0.1 (2023-02-09)
+------------------
+
+* #53 Check memcached get resultCode more closely (@phil-davis)
+
 2.0.0 (2022-08-23)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '2.0.0';
+    public const VERSION = '2.0.1';
 }


### PR DESCRIPTION
IMO this is a patch release because the change fixes the Memcached `get()` method so that it more accurately follows the spec for the cases where:
1) an invalid key is provided (has white space, too long or whatever else might be invalid) - throws an exception
2) something goes wrong with access to the Memcached server (returns the expected default (usually `null`) so that the caller will infer a cache miss)

Both of those should be an improvement for consumers.