### PR TITLE
chore: use php-cs-fixer 3.49

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "psr/simple-cache-implementation": "~1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.38.0",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",


### PR DESCRIPTION
Recent php-cs-fixer minor releases suggest some new things.
For example, see PR https://github.com/sabre-io/xml/pull/271

It passes here in https://github.com/sabre-io/cache so no code needs to be touched, but I may as well bump the required php-cs-fixer version to match with other repos.