### PR TITLE
chore: add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github/          export-ignore
+/tests/            export-ignore
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
+/.php_cs.dist      export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/CHANGELOG.md      export-ignore
+/README.md         export-ignore
+/phpstan.neon      export-ignore

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "psr/simple-cache-implementation": "~1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.51",
+        "friendsofphp/php-cs-fixer": "^3.56",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",


### PR DESCRIPTION
to be like other repos - e.g. see https://github.com/sabre-io/xml/pull/282

And delete unused bin directory, same as was done in https://github.com/sabre-io/xml/pull/281

While I am here, bump the required version of php-cs-fixer so that we are always using at least the version that currently is known to pass in CI.