### PR TITLE
test: allow phpunit 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             code-style: 'yes'
             code-analysis: 'yes'
           - php-versions: '8.4'
-            coverage: 'none'
+            coverage: 'pcov'
             code-style: 'yes'
             code-analysis: 'yes'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Memcached
         uses: KeisukeYamashita/memcached-actions@v1
@@ -72,5 +72,5 @@ jobs:
           MEMCACHED_SERVER: 127.0.0.1
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.coverage != 'none'

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit" : "^9.6"
+        "phpunit/phpunit" : "^9.6|^10.5"
     },
     "scripts": {
         "phpstan": [

--- a/tests/Cache/AbstractCacheTestClass.php
+++ b/tests/Cache/AbstractCacheTestClass.php
@@ -10,7 +10,7 @@ use Psr\SimpleCache\CacheInterface;
  * Because all cache implementations should mostly behave the same way, they
  * can all extend this test.
  */
-abstract class AbstractCacheTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractCacheTestClass extends \PHPUnit\Framework\TestCase
 {
     abstract public function getCache(): CacheInterface;
 

--- a/tests/Cache/ApcuTest.php
+++ b/tests/Cache/ApcuTest.php
@@ -6,7 +6,7 @@ namespace Sabre\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class ApcuTest extends AbstractCacheTest
+class ApcuTest extends AbstractCacheTestClass
 {
     public function getCache(): CacheInterface
     {

--- a/tests/Cache/MemcachedTest.php
+++ b/tests/Cache/MemcachedTest.php
@@ -6,7 +6,7 @@ namespace Sabre\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class MemcachedTest extends AbstractCacheTest
+class MemcachedTest extends AbstractCacheTestClass
 {
     public function getCache(): CacheInterface
     {

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -6,7 +6,7 @@ namespace Sabre\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
-class MemoryCacheTest extends AbstractCacheTest
+class MemoryCacheTest extends AbstractCacheTestClass
 {
     public function getCache(): CacheInterface
     {


### PR DESCRIPTION
Try this in `cache` first just to see what happens.

1) phpunit 10 does not accept abstract classes for test code, ending with "Test".
```
There was 1 PHPUnit test runner warning:

1) Class Sabre\Cache\AbstractCacheTest declared in /home/runner/work/cache/cache/tests/Cache/AbstractCacheTest.php is abstract
```
I renamed `AbstractCacheTest` to `AbstractCacheTestClass` and that stopped the warning.

2) In PHP 8.4 we were running `phpunit` and asking to produce test coverage data, but hadn't specified the coverage driver "pcov". PHPunit 9 had not made that a failure, but PHPunit 10 fails (correctly) in that case. I fixed it.

PHPunit 10 also gives the message:
```
There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
```
That does not fail the test pipeline. We can't do anything about that, because we need to have the phpunit XML config in the version 9 format so that we can use it on PHP 7.4. An alternative would be to update it, and put the old phpunit XML in a different file that we use when running PHPunit 9. That seems too complex/tricky.