### PR TITLE
Prepare release 2.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
-        code-style: ['no']
+        code-style: ['yes']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
@@ -23,7 +23,7 @@ jobs:
             code-analysis: 'yes'
           - php-versions: '8.4'
             coverage: 'none'
-            code-style: 'no'
+            code-style: 'yes'
             code-analysis: 'yes'
 
     steps:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Code Analysis (PHP CS-Fixer)
         if: matrix.code-style == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,6 +10,10 @@ $config->getFinder()
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 
 return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+2.0.2 (2024-08-27)
+------------------
+
+* #61 cleanup code for phpstan level 2 (@phil-davis)
+* #67 remove unused bin directory (@phil-davis)
+* #69 add PHP 8.4 to CI (@phil-davis)
+
 2.0.1 (2023-02-09)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "psr/simple-cache-implementation": "~1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.60",
-        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.63",
+        "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",
         "phpstan/extension-installer": "^1.4",
@@ -55,7 +55,7 @@
             "phpstan analyse lib tests"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '2.0.1';
+    public const VERSION = '2.0.2';
 }


### PR DESCRIPTION
- latest php-cs-fixer and phpstan
- changelog and version bump

This release has a lot of tooling updates from the last 18 months, which have applied some code-style etc. changes to the actual code. But behavior should be the same.

