### PR TITLE
ci: bump minimum tool versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
         "phpunit/phpunit": "^11.5",
-        "rector/rector": "^2.4"
+        "rector/rector": "^2.5"
     },
     "scripts": {
         "phpstan": [


### PR DESCRIPTION
Record the current minor versions of tools that are really in use in CI.
(mainly an excuse to run CI to check that it is still passing)