### PR TITLE
ci: add PHP 8.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
             code-style: 'yes'
             code-analysis: 'yes'
             rector-check: 'yes'
+          - php-versions: '8.6'
+            coverage: 'pcov'
+            code-style: 'yes'
+            code-analysis: 'yes'
+            rector-check: 'yes'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
leaving the other test matrices for PHP unchanged for now.

Run all CI checks on PHP 8.6.

This is just a draft PR to check that CI passes. When PHP 8.6 gets to the RC stage, then I will make a real PR to add 8.6.